### PR TITLE
Docs: add PHPDoc for rest_revision_query filter

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
@@ -226,6 +226,8 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 	 *
 	 * @since 4.7.0
 	 *
+	 * @see WP_REST_Posts_Controller::get_items()
+	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
@@ -297,7 +299,17 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 				$args['update_post_meta_cache'] = false;
 			}
 
-			/** This filter is documented in wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php */
+			/**
+			 * Filters WP_Query arguments when querying revisions via the REST API.
+			 *
+			 * Serves the same purpose as the {@see 'rest_{$this->post_type}_query'} filter in
+			 * WP_REST_Posts_Controller, but for the standalone WP_REST_Revisions_Controller.
+			 *
+			 * @since 4.7.0
+			 *
+			 * @param array           $args    Array of arguments for WP_Query.
+			 * @param WP_REST_Request $request The REST API request.
+			 */
 			$args = apply_filters( 'rest_revision_query', $args, $request );
 			if ( ! is_array( $args ) ) {
 				$args = array();


### PR DESCRIPTION
## Summary

The `rest_revision_query` filter in `WP_REST_Revisions_Controller::get_items()` carried a cross-reference comment claiming it was documented in the posts controller:

```php
/** This filter is documented in wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php */
$args = apply_filters( 'rest_revision_query', $args, $request );
```

That cross-reference is incorrect. The posts controller documents `rest_{$this->post_type}_query` — a dynamic hook that fires only for post types managed by `WP_REST_Posts_Controller`. `WP_REST_Revisions_Controller` extends `WP_REST_Controller` directly (not the posts controller), so the dynamic hook never fires for revisions. `rest_revision_query` is a standalone hook and has never had its own PHPDoc block.

For deeper context, including the architectural investigation and prior-art research for the documentation approach, see: apermo/wordpress-develop#9

## Changes

- Replace the broken cross-reference comment with a proper `@since 4.7.0` PHPDoc block for `rest_revision_query`
- Add `@see WP_REST_Posts_Controller::get_items()` to the `get_items()` method docblock to surface the parallel relationship between the two controllers, following the same `{@see}` pattern used in `comment.php` and `post.php` for related hooks

Trac ticket: https://core.trac.wordpress.org/ticket/64224

## Use of AI Tools

Research (architectural investigation, prior-art search across core) and code were produced by Claude Code (claude-sonnet-4-6). The contributor reviewed the findings, steered the documentation approach, and approved the final implementation.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**